### PR TITLE
Add lastSeenOn to Devices

### DIFF
--- a/src/steps/constants.ts
+++ b/src/steps/constants.ts
@@ -53,6 +53,7 @@ export const Entities: Record<
         lastEventNpaStatus: { type: 'string' },
         lastEventActor: { type: 'string' },
         lastEventOccurredOn: { type: 'number' },
+        lastSeenOn: { type: 'number' },
       },
       required: ['id'],
     },

--- a/src/steps/device/__snapshots__/index.test.ts.snap
+++ b/src/steps/device/__snapshots__/index.test.ts.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`build-tenant-and-device-relationships 1`] = `
+Object {
+  "_class": Array [
+    "Device",
+  ],
+  "_key": "netskope_device:CLW247-360",
+  "_type": "netskope_device",
+  "category": "Windows",
+  "clientInstallTime": 1628251103,
+  "clientVersion": "94.1.1.960",
+  "createdOn": undefined,
+  "deviceId": "CLW247-360",
+  "displayName": "CLW247-360",
+  "id": "CLW247-360",
+  "lastEvent": "System shutdown",
+  "lastEventActor": "System",
+  "lastEventNpaStatus": "Steering Disabled",
+  "lastEventOccurredOn": 1653479089,
+  "lastEventStatus": "Disabled",
+  "lastSeenOn": 1653479089,
+  "make": "Dell Inc.",
+  "model": "Vostro 3580",
+  "name": "CLW247-360",
+  "os": "Windows",
+  "osVersion": "10.0 (2009)",
+  "serial": "[REDACTED]",
+}
+`;

--- a/src/steps/device/converter.ts
+++ b/src/steps/device/converter.ts
@@ -40,6 +40,7 @@ export function createDeviceEntity(device: Device): Entity {
           dev.last_event.timestamp,
           'ms',
         ),
+        lastSeenOn: parseTimePropertyValue(dev.last_event.timestamp, 'ms'),
       },
     },
   });

--- a/src/steps/device/index.test.ts
+++ b/src/steps/device/index.test.ts
@@ -2,6 +2,7 @@ import { executeStepWithDependencies } from '@jupiterone/integration-sdk-testing
 import { buildStepTestConfigForStep } from '../../../test/config';
 import { Recording, setupProjectRecording } from '../../../test/recording';
 import { IntegrationSteps } from '../constants';
+import { omit } from 'lodash';
 
 // See test/README.md for details
 let recording: Recording;
@@ -18,4 +19,5 @@ test('build-tenant-and-device-relationships', async () => {
   const stepConfig = buildStepTestConfigForStep(IntegrationSteps.DEVICES);
   const stepResult = await executeStepWithDependencies(stepConfig);
   expect(stepResult).toMatchStepMetadata(stepConfig);
+  expect(omit(stepResult.collectedEntities[0], ['_rawData'])).toMatchSnapshot();
 });


### PR DESCRIPTION
# Description

Thank you for contributing to a JupiterOne integration!

Added the `lastSeenOn` property to Devices.

## Summary

Added the `lastSeenOn` property to Devices.

## Type of change

Please leave any irrelevant options unchecked.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [x] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [x] My changes properly paginate the target service provider's API
- [x] My changes properly handle rate limiting of the target service provider's
      API
- [x] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [x] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [ ] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
